### PR TITLE
Remove namespace in SetUpFixture

### DIFF
--- a/tests/NServiceBus.MSDependencyInjection.Tests/SetUpFixture.cs
+++ b/tests/NServiceBus.MSDependencyInjection.Tests/SetUpFixture.cs
@@ -2,14 +2,11 @@
 using NServiceBus.ObjectBuilder.MSDependencyInjection;
 using NUnit.Framework;
 
-namespace NServiceBus.MSDependencyInjection.Tests
+[SetUpFixture]
+public class SetUpFixture
 {
-    [SetUpFixture]
-    public class SetUpFixture
+    public SetUpFixture()
     {
-        public SetUpFixture()
-        {
-            TestContainerBuilder.ConstructBuilder = () => new ServicesObjectBuilder();
-        }
+        TestContainerBuilder.ConstructBuilder = () => new ServicesObjectBuilder();
     }
 }


### PR DESCRIPTION
the setup shouldn't have a namespace because otherwise the tests imported from the `NServiceBus.ContainerTests.Sources` package use the built-in LightInject builder.

Caution: This change breaks a lot of tests!