### PR TITLE
Custom provider factory

### DIFF
--- a/samples/AspNetCoreSample/Startup.cs
+++ b/samples/AspNetCoreSample/Startup.cs
@@ -25,7 +25,7 @@ namespace Sample.Core
                     customizations.ExistingServices(services);
                 });
 
-            endpoint = Endpoint.Start(endpointConfiguration).GetAwaiter().GetResult();
+            endpoint = NServiceBus.Endpoint.Start(endpointConfiguration).GetAwaiter().GetResult();
         }
 
         #endregion

--- a/src/NServiceBus.MSDependencyInjection/ServicesExtensions.cs
+++ b/src/NServiceBus.MSDependencyInjection/ServicesExtensions.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using NServiceBus.Container;
+using NServiceBus.ObjectBuilder.MSDependencyInjection;
 
 namespace NServiceBus
 {
@@ -16,6 +18,11 @@ namespace NServiceBus
         public static void ExistingServices(this ContainerCustomizations customizations, IServiceCollection services)
         {
             customizations.Settings.Set<ServicesBuilder.CollectionHolder>(new ServicesBuilder.CollectionHolder(services));
+        }
+
+        public static void ServiceProviderFactory(this ContainerCustomizations customizations, Func<IServiceCollection, UpdateableServiceProvider> serviceProviderFactory)
+        {
+            customizations.Settings.Set<Func<IServiceCollection, UpdateableServiceProvider>>(serviceProviderFactory);
         }
     }
 }

--- a/src/NServiceBus.MSDependencyInjection/ServicesObjectBuilder.cs
+++ b/src/NServiceBus.MSDependencyInjection/ServicesObjectBuilder.cs
@@ -16,22 +16,22 @@ namespace NServiceBus.ObjectBuilder.MSDependencyInjection
         private readonly IServiceCollection _services;
         private readonly IServiceScope _scope;
 
-        public ServicesObjectBuilder() : this(new ServiceCollection(), true)
+        public ServicesObjectBuilder(Func<IServiceCollection, UpdateableServiceProvider> serviceProviderFactory) : this(new ServiceCollection(), true, serviceProviderFactory)
         {
         }
 
-        public ServicesObjectBuilder(IServiceCollection services) : this(services, false)
+        public ServicesObjectBuilder(IServiceCollection services, Func<IServiceCollection, UpdateableServiceProvider> serviceProviderFactory) : this(services, false, serviceProviderFactory)
         {
         }
 
-        public ServicesObjectBuilder(IServiceCollection services, bool owned)
+        public ServicesObjectBuilder(IServiceCollection services, bool owned, Func<IServiceCollection, UpdateableServiceProvider> serviceProviderFactory)
         {
             if (services == null)
                 throw new ArgumentNullException(nameof(services), "The object builder must be initialized with a valid service collection instance.");
 
             _owned = owned;
-            _runtimeServiceProvider = new UpdateableServiceProvider(services);
             _services = services;
+            _runtimeServiceProvider = serviceProviderFactory(_services);
         }
 
         private ServicesObjectBuilder(bool owned, UpdateableServiceProvider updateableServiceProvider)

--- a/src/NServiceBus.MSDependencyInjection/UpdateableServiceProvider.cs
+++ b/src/NServiceBus.MSDependencyInjection/UpdateableServiceProvider.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace NServiceBus.ObjectBuilder.MSDependencyInjection
 {
-    internal class UpdateableServiceProvider : IServiceProvider, IServiceCollection, IDisposable
+    public class UpdateableServiceProvider : IServiceProvider, IServiceCollection, IDisposable
     {
         private IServiceProvider _serviceProvider;
         private readonly ServiceCollection _services;

--- a/tests/NServiceBus.MSDependencyInjection.Tests/DisposalTests.cs
+++ b/tests/NServiceBus.MSDependencyInjection.Tests/DisposalTests.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using NServiceBus.ObjectBuilder.MSDependencyInjection;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus.ObjectBuilder.MSDependencyInjection;
+using NUnit.Framework;
 
 namespace NServiceBus.MSDependencyInjection.Tests
 {
@@ -15,7 +15,7 @@ namespace NServiceBus.MSDependencyInjection.Tests
         {
             var fakesServiceProvider = new FakeServiceProvider();
 
-            var container = new ServicesObjectBuilder(fakesServiceProvider, true);
+            var container = new ServicesObjectBuilder(fakesServiceProvider, true, sc => new UpdateableServiceProvider(sc));
             container.Dispose();
 
             Assert.True(fakesServiceProvider.Disposed);
@@ -26,7 +26,7 @@ namespace NServiceBus.MSDependencyInjection.Tests
         {
             var fakesServiceProvider = new FakeServiceProvider();
 
-            var container = new ServicesObjectBuilder(fakesServiceProvider, false);
+            var container = new ServicesObjectBuilder(fakesServiceProvider, false, sc => new UpdateableServiceProvider(sc));
             container.Dispose();
 
             Assert.False(fakesServiceProvider.Disposed);

--- a/tests/NServiceBus.MSDependencyInjection.Tests/SetUpFixture.cs
+++ b/tests/NServiceBus.MSDependencyInjection.Tests/SetUpFixture.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.MSDependencyInjection.Tests
     {
         public SetUpFixture()
         {
-            TestContainerBuilder.ConstructBuilder = () => new ServicesObjectBuilder();
+            TestContainerBuilder.ConstructBuilder = () => new ServicesObjectBuilder(sc => new UpdateableServiceProvider(sc));
         }
     }
 }

--- a/tests/NServiceBus.MSDependencyInjection.Tests/When_registering_components.cs
+++ b/tests/NServiceBus.MSDependencyInjection.Tests/When_registering_components.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.MSDependencyInjection.Tests
             var services = new ServiceCollection();
             services.AddTransient(typeof(DependentType));
 
-            using (var builder = new ServicesObjectBuilder(services))
+            using (var builder = new ServicesObjectBuilder(services, sc => new UpdateableServiceProvider(sc)))
             {
                 builder.Configure(typeof(RequestingType), DependencyLifecycle.InstancePerCall);
 


### PR DESCRIPTION
When integrating with ASP.Net Core it's mandatory that the service provider instance it's shared across NServiceBus and the .NET Core runtime. To do so the NServiceBus used container, as it is the one created first, needs to be returned from the `ConfigureServices` method, e.g.:

```
public IServiceProvider ConfigureServices(IServiceCollection services)
{
   //create the container wrapping the services collection
   //return the container instance
}
```

To allow the above approach users need to be able to inject a custom service provider factory so to have full control over the container instance creation. This PR contains a very draft/raw set of changes to:

- expose the `UpdatableServiceProvider` class to users code
- introduce a `ServiceProviderFactory` configuration extension

The end goal is to be able to write something like:

```
public IServiceProvider ConfigureServices(IServiceCollection services)
{
    services.AddSignalR();
    services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

    IEndpointInstance endpointInstance = null;
    services.AddSingleton<IMessageSession>(_ => endpointInstance);

    var ec = new EndpointConfiguration("NServiceBusSignalRCallback");
    ec.UseTransport<LearningTransport>();

    UpdateableServiceProvider container = null;
    ec.UseContainer<ServicesBuilder>(c =>
    {
        c.ExistingServices(services);
        c.ServiceProviderFactory(sc => 
        {
            container = new UpdateableServiceProvider(sc);
            return container;
        });
    });

    endpointInstance = Endpoint.Start(ec).GetAwaiter().GetResult();

    return container;
}
```

With the above code NServiceBus and .NET Core share the same container instance and bi-directional resolution of components works as expected. More details on the problem this attempts to solve are available in this thread: https://discuss.particular.net/t/support-for-microsoft-extensions-dependencyinjection/129

@twenzel the current implementation is just a way to demonstrate the need, feel free to rework this PR as you prefer. If you have any questions, please, do not hesitate to ping me.